### PR TITLE
Add timeline time-capsule page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,30 @@
-"use client";
+import { manualMilestones } from "@/data/manualMilestones"
+import Timeline from "@/components/Timeline"
+import { TimelineEntryData } from "@/components/TimelineEntry"
+import { fetchRepos } from "@/lib/github"
 
-import HeroSection from '@/components/HeroSection';
-import FeaturesSection from '@/components/FeaturesSection';
-import ProjectsSection from '@/components/ProjectsSection';
-import ContactSection from '@/components/ContactSection';
+function mapMilestones(): TimelineEntryData[] {
+  return manualMilestones.map(m => ({
+    date: m.date,
+    title: m.title,
+    description: m.description,
+  }))
+}
 
-export default function Home() {
-  return (
-    <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
-      <HeroSection />
-      <FeaturesSection />
-      <ProjectsSection />
-      <ContactSection />
-    </div>
-  );
+async function mapRepos(): Promise<TimelineEntryData[]> {
+  const repos = await fetchRepos("SebastianBoehler")
+  return repos.map(r => ({
+    date: r.created_at,
+    title: r.name,
+    description: r.description || "",
+    link: r.html_url,
+  }))
+}
+
+export default async function Home() {
+  const [milestones, repos] = await Promise.all([mapMilestones(), mapRepos()])
+  const entries = [...milestones, ...repos].sort((a, b) =>
+    b.date.localeCompare(a.date)
+  )
+  return <Timeline entries={entries} />
 }

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,0 +1,26 @@
+import TimelineEntry, { TimelineEntryData } from "./TimelineEntry"
+
+export default function Timeline({ entries }: { entries: TimelineEntryData[] }) {
+  const groups = entries.reduce<Record<string, TimelineEntryData[]>>((acc, entry) => {
+    const year = entry.date.slice(0, 4)
+    acc[year] = acc[year] || []
+    acc[year].push(entry)
+    return acc
+  }, {})
+  const years = Object.keys(groups).sort((a, b) => Number(b) - Number(a))
+
+  return (
+    <div className="h-screen overflow-y-scroll snap-y snap-mandatory">
+      {years.map(year => (
+        <section key={year} className="snap-start min-h-screen flex flex-col items-center justify-center px-4 py-20">
+          <h2 className="heading-2 mb-12">{year}</h2>
+          <div className="space-y-12 max-w-xl w-full">
+            {groups[year].map((entry, idx) => (
+              <TimelineEntry key={idx} entry={entry} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/src/components/TimelineEntry.tsx
+++ b/src/components/TimelineEntry.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useInView } from "@/hooks/useInView"
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion"
+import { cn } from "@/lib/utils"
+
+export interface TimelineEntryData {
+  date: string
+  title: string
+  description: string
+  icon?: string
+  link?: string
+}
+
+export default function TimelineEntry({ entry }: { entry: TimelineEntryData }) {
+  const { ref, inView } = useInView({ threshold: 0.1 })
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  return (
+    <div
+      ref={ref as any}
+      className={cn(
+        "relative pl-8 border-l border-gray-300 dark:border-gray-700",
+        "opacity-0 translate-y-4 transition-all duration-700", 
+        (inView || prefersReducedMotion) && "opacity-100 translate-y-0"
+      )}
+    >
+      {entry.icon && (
+        <span className="absolute -left-4 top-0 text-xl">{entry.icon}</span>
+      )}
+      <time className="text-sm text-gray-500 dark:text-gray-400 block mb-1">
+        {new Date(entry.date).toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "long",
+        })}
+      </time>
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+        {entry.link ? (
+          <a href={entry.link} target="_blank" rel="noopener noreferrer" className="hover:underline">
+            {entry.title}
+          </a>
+        ) : (
+          entry.title
+        )}
+      </h3>
+      <p className="text-gray-600 dark:text-gray-300 mt-1">{entry.description}</p>
+    </div>
+  )
+}

--- a/src/data/manualMilestones.ts
+++ b/src/data/manualMilestones.ts
@@ -1,0 +1,93 @@
+export const manualMilestones = [
+  {
+    date: "2013-06-01",
+    title: "Built LED systems into Lego cars",
+    description:
+      "Started experimenting with electronics by soldering circuits and embedding LEDs into Lego vehicles. Early interest in electrical engineering."
+  },
+  {
+    date: "2014-03-01",
+    title: "Learned Photoshop & After Effects",
+    description:
+      "Began editing Minecraft YouTube intros using Photoshop and After Effects. Designed channel banners and graphics."
+  },
+  {
+    date: "2015-09-01",
+    title: "Hosted Minecraft server",
+    description:
+      "Wrote Bukkit/Spigot plugins in Java, hosted own server with custom features and admin tools for classmates."
+  },
+  {
+    date: "2016-09-01",
+    title: "First motion-graphic experiment",
+    description:
+      "Edited flames and explosions into a school video using Adobe After Effects during 9th grade."
+  },
+  {
+    date: "2017-04-01",
+    title: "Deeper motion design & title sequences",
+    description:
+      "Created advanced motion graphics and lower-thirds for school projects using After Effects."
+  },
+  {
+    date: "2018-07-01",
+    title: "Early backend experience",
+    description:
+      "Started writing REST APIs and Discord bots in JavaScript and TypeScript for hobby projects."
+  },
+  {
+    date: "2019-10-01",
+    title: "Supreme Coppod project",
+    description:
+      "Co-founded project (later rebranded to Böhler Supreme and Loop Supreme). Led marketing, Discord support, and design."
+  },
+  {
+    date: "2020-06-01",
+    title: "Completed Abitur (High School Graduation)",
+    description:
+      "Finished high school with a focus on science and tech. Ready for full-time development."
+  },
+  {
+    date: "2020-09-01",
+    title: "Started work at Remote Lee GmbH",
+    description:
+      "Joined as a backend developer during or shortly after school. Gained early professional experience."
+  },
+  {
+    date: "2021-03-01",
+    title: "Began work at LIFI",
+    description:
+      "Worked on backend systems for a crypto/DeFi-related product. Deepened experience with APIs, cloud, and blockchain."
+  },
+  {
+    date: "2022-01-01",
+    title: "Founded HB Capital",
+    description:
+      "Started trading-focused company with Justus. Built algorithmic crypto trading systems, handled all tech development."
+  },
+  {
+    date: "2023-05-01",
+    title: "Security system AI prototype",
+    description:
+      "Created AI-powered object detection tool for Hikvision cameras using YOLO + Segment Anything. Ran on RTSP stream."
+  },
+  {
+    date: "2023-09-01",
+    title: "University studies started",
+    description:
+      "Began B.Sc. in Computer Science at IU Internationale Hochschule. Studying full-time, fast-tracking degree."
+  },
+  {
+    date: "2024-04-01",
+    title: "Started AI voice assistant prototype",
+    description:
+      "Began prototyping speech-to-speech agent with LLM backend and modular function-calling, aimed at iOS integration."
+  },
+  {
+    date: "2024-06-01",
+    title: "Sunderlabs UG founded",
+    description:
+      "Formally registered new company for AI experiments and products such as personal agents and learning tools."
+  }
+] as const
+export type ManualMilestone = (typeof manualMilestones)[number]

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef, useState } from "react"
+
+export function useInView(options?: IntersectionObserverInit) {
+  const ref = useRef<HTMLElement | null>(null)
+  const [inView, setInView] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setInView(true)
+        observer.unobserve(entry.target)
+      }
+    }, options)
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [options])
+
+  return { ref, inView }
+}

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react"
+
+export function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
+    setPrefersReducedMotion(mediaQuery.matches)
+    const handler = () => setPrefersReducedMotion(mediaQuery.matches)
+    mediaQuery.addEventListener("change", handler)
+    return () => mediaQuery.removeEventListener("change", handler)
+  }, [])
+
+  return prefersReducedMotion
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,26 @@
+export interface Repo {
+  name: string
+  description: string | null
+  html_url: string
+  created_at: string
+  fork: boolean
+}
+
+export async function fetchRepos(username: string): Promise<Repo[]> {
+  const headers: HeadersInit = { Accept: "application/vnd.github+json" }
+  if (process.env.GH_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GH_TOKEN}`
+  }
+
+  const res = await fetch(`https://api.github.com/users/${username}/repos?per_page=100`, {
+    headers,
+    next: { revalidate: 60 * 60 },
+  })
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch repos: ${res.status}`)
+  }
+
+  const data = (await res.json()) as Repo[]
+  return data.filter(repo => !repo.fork)
+}


### PR DESCRIPTION
## Summary
- add manual milestone data
- fetch GitHub repos at build time with `GH_TOKEN`
- implement `useInView` and `usePrefersReducedMotion` hooks
- create Timeline components with scroll snapping and intersection animations
- replace homepage with timeline view
- extend manual milestones through 2024

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch to github.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a4f74969c8328bbc2413e98367127