### PR TITLE
Refine hero section height and add link cues

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,6 @@ export default function Header() {
 
   const menuItems = [
     { label: 'About', href: '#about' },
-    { label: 'Projects', href: '#projects' },
     { label: 'Contact', href: '#contact' },
   ];
 

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -1,27 +1,22 @@
-import { Linkedin, Twitter } from 'lucide-react'
-
 export default function SocialLinks() {
   return (
-    <section className="snap-start min-h-[50vh] flex flex-col items-center justify-center px-4 py-20">
-      <h1 className="heading-1 mb-6">Connect with me</h1>
-      <div className="flex space-x-6">
+    <section className="snap-start flex justify-center py-8">
+      <div className="flex space-x-6 text-lg">
         <a
           href="https://www.linkedin.com/in/sebastian-boehler?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=ios_app"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors flex items-center space-x-2"
+          className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
         >
-          <Linkedin className="h-5 w-5" />
-          <span>LinkedIn</span>
+          LinkedIn
         </a>
         <a
           href="https://x.com/sebastianboehle?s=21"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors flex items-center space-x-2"
+          className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
         >
-          <Twitter className="h-5 w-5" />
-          <span>X</span>
+          X
         </a>
       </div>
     </section>

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -2,7 +2,7 @@ import { Linkedin, Twitter } from 'lucide-react'
 
 export default function SocialLinks() {
   return (
-    <section className="snap-start min-h-screen flex flex-col items-center justify-center px-4 py-20">
+    <section className="snap-start min-h-[50vh] flex flex-col items-center justify-center px-4 py-20">
       <h1 className="heading-1 mb-6">Connect with me</h1>
       <div className="flex space-x-6">
         <a

--- a/src/components/TimelineEntry.tsx
+++ b/src/components/TimelineEntry.tsx
@@ -3,6 +3,7 @@
 import { useInView } from "@/hooks/useInView"
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion"
 import { cn } from "@/lib/utils"
+import { ExternalLink } from "lucide-react"
 
 export interface TimelineEntryData {
   date: string
@@ -36,8 +37,14 @@ export default function TimelineEntry({ entry }: { entry: TimelineEntryData }) {
       </time>
       <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
         {entry.link ? (
-          <a href={entry.link} target="_blank" rel="noopener noreferrer" className="hover:underline">
+          <a
+            href={entry.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline"
+          >
             {entry.title}
+            <ExternalLink className="h-4 w-4" />
           </a>
         ) : (
           entry.title


### PR DESCRIPTION
## Summary
- shrink SocialLinks hero section so the timeline is visible on load
- drop the "Projects" entry from the header menu
- show an external link icon on timeline items with links

## Testing
- `bun run lint`
- `bun run build` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685a94fb5e80832887316edc632a5b7f