### PR TITLE
Add commit activity bar chart to timeline

### DIFF
--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -1,7 +1,7 @@
 import { manualMilestones } from "@/data/manualMilestones"
 import Timeline from "@/components/Timeline"
 import { TimelineEntryData } from "@/components/TimelineEntry"
-import { fetchRepos } from "@/lib/github"
+import { fetchRepos, fetchContributions } from "@/lib/github"
 
 async function mapRepos(): Promise<TimelineEntryData[]> {
   const repos = await fetchRepos("SebastianBoehler")
@@ -21,9 +21,10 @@ export const metadata = {
 export default async function TimelinePage() {
   const repos = await mapRepos()
   const entries = [...manualMilestones, ...repos].sort((a, b) => b.date.localeCompare(a.date))
+  const contributions = await fetchContributions("SebastianBoehler")
   return (
     <main>
-      <Timeline entries={entries} />
+      <Timeline entries={entries} contributions={contributions} />
     </main>
   )
 }

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -22,6 +22,8 @@ export default async function TimelinePage() {
   const repos = await mapRepos()
   const entries = [...manualMilestones, ...repos].sort((a, b) => b.date.localeCompare(a.date))
   const contributions = await fetchContributions("SebastianBoehler")
+  console.log('[TimelinePage] repos:', repos.length, 'manualMilestones:', manualMilestones.length, 'entries total:', entries.length)
+  console.log('[TimelinePage] contributions years:', contributions.map(c => c.year), 'sum total:', contributions.reduce((a, c) => a + c.total, 0))
   return (
     <main>
       <Timeline entries={entries} contributions={contributions} />

--- a/src/components/CommitActivityChart.tsx
+++ b/src/components/CommitActivityChart.tsx
@@ -1,0 +1,32 @@
+interface Contribution {
+  year: string
+  total: number
+}
+
+interface Props {
+  data: Contribution[]
+  activeYear: string
+}
+
+export default function CommitActivityChart({ data, activeYear }: Props) {
+  if (data.length === 0) return null
+  const max = Math.max(...data.map((d) => d.total))
+  return (
+    <div className="flex h-32 w-full items-end gap-2 mb-8">
+      {data.map((d) => (
+        <div key={d.year} className="flex-1 flex flex-col items-center">
+          <div
+            className={`${
+              d.year === activeYear
+                ? 'bg-blue-600 dark:bg-blue-400'
+                : 'bg-gray-300 dark:bg-gray-700'
+            } w-full transition-colors`}
+            style={{ height: `${(d.total / max) * 100}%` }}
+            aria-label={`${d.year}: ${d.total} commits`}
+          />
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{d.year}</p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/CommitActivityChart.tsx
+++ b/src/components/CommitActivityChart.tsx
@@ -9,21 +9,29 @@ interface Props {
 }
 
 export default function CommitActivityChart({ data, activeYear }: Props) {
-  if (data.length === 0) return null
+  console.log('[CommitActivityChart] props', { data, activeYear })
+  if (data.length === 0) {
+    console.log('[CommitActivityChart] No data provided')
+    return null
+  }
   const max = Math.max(...data.map((d) => d.total))
+  const denom = max > 0 ? max : 1
+  console.log('[CommitActivityChart] max total', max)
   return (
-    <div className="flex h-32 w-full items-end gap-2 mb-8">
+    <div className="flex w-full gap-2 mb-8">
       {data.map((d) => (
         <div key={d.year} className="flex-1 flex flex-col items-center">
-          <div
-            className={`${
-              d.year === activeYear
-                ? 'bg-blue-600 dark:bg-blue-400'
-                : 'bg-gray-300 dark:bg-gray-700'
-            } w-full transition-colors`}
-            style={{ height: `${(d.total / max) * 100}%` }}
-            aria-label={`${d.year}: ${d.total} commits`}
-          />
+          <div className="w-full h-32 flex items-end">
+            <div
+              className={`${
+                d.year === activeYear
+                  ? 'bg-blue-600 dark:bg-blue-400'
+                  : 'bg-gray-300 dark:bg-gray-700'
+              } mx-auto w-[2px] md:w-[3px] lg:w-[4px] rounded transition-colors`}
+              style={{ height: `${(d.total / denom) * 100}%` }}
+              aria-label={`${d.year}: ${d.total} commits`}
+            />
+          </div>
           <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{d.year}</p>
         </div>
       ))}

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -19,6 +19,9 @@ export default function Timeline({ entries, contributions }: Props) {
   }, {})
   const years = Object.keys(groups).sort((a, b) => Number(b) - Number(a))
 
+  console.log('[Timeline] groups', groups)
+  console.log('[Timeline] years', years)
+
   const [activeYear, setActiveYear] = useState(years[0])
   const yearRefs = useRef<Record<string, HTMLElement | null>>({})
 
@@ -28,7 +31,10 @@ export default function Timeline({ entries, contributions }: Props) {
         entries.forEach(entry => {
           if (entry.isIntersecting) {
             const y = entry.target.getAttribute('data-year')
-            if (y) setActiveYear(y)
+            if (y) {
+              console.log('[Timeline] Intersection observed, setting activeYear', y)
+              setActiveYear(y)
+            }
           }
         })
       },
@@ -41,11 +47,19 @@ export default function Timeline({ entries, contributions }: Props) {
     return () => observer.disconnect()
   }, [years])
 
+  useEffect(() => {
+    console.log('[Timeline] activeYear changed', activeYear)
+  }, [activeYear])
+
+  console.log('[Timeline] contributions input', contributions)
   const chartData = contributions.filter(c => years.includes(c.year))
+  console.log('[Timeline] chartData (filtered to years)', chartData)
 
   return (
     <div>
-      <CommitActivityChart data={chartData} activeYear={activeYear} />
+      <div className="sticky top-16 z-40 bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm">
+        <CommitActivityChart data={chartData} activeYear={activeYear} />
+      </div>
       <div className="snap-y snap-mandatory">
         {years.map(year => (
           <section

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -50,7 +50,9 @@ export default function Timeline({ entries, contributions }: Props) {
         {years.map(year => (
           <section
             key={year}
-            ref={el => (yearRefs.current[year] = el)}
+            ref={el => {
+              yearRefs.current[year] = el
+            }}
             data-year={year}
             className="snap-start min-h-screen flex flex-col items-center justify-center px-4 py-20"
           >

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,6 +1,16 @@
-import TimelineEntry, { TimelineEntryData } from "./TimelineEntry"
+"use client";
 
-export default function Timeline({ entries }: { entries: TimelineEntryData[] }) {
+import { useEffect, useRef, useState } from 'react'
+import TimelineEntry, { TimelineEntryData } from './TimelineEntry'
+import CommitActivityChart from './CommitActivityChart'
+import { ContributionYear } from '@/lib/github'
+
+interface Props {
+  entries: TimelineEntryData[]
+  contributions: ContributionYear[]
+}
+
+export default function Timeline({ entries, contributions }: Props) {
   const groups = entries.reduce<Record<string, TimelineEntryData[]>>((acc, entry) => {
     const year = entry.date.slice(0, 4)
     acc[year] = acc[year] || []
@@ -9,18 +19,50 @@ export default function Timeline({ entries }: { entries: TimelineEntryData[] }) 
   }, {})
   const years = Object.keys(groups).sort((a, b) => Number(b) - Number(a))
 
+  const [activeYear, setActiveYear] = useState(years[0])
+  const yearRefs = useRef<Record<string, HTMLElement | null>>({})
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            const y = entry.target.getAttribute('data-year')
+            if (y) setActiveYear(y)
+          }
+        })
+      },
+      { threshold: 0.6 }
+    )
+    years.forEach(year => {
+      const el = yearRefs.current[year]
+      if (el) observer.observe(el)
+    })
+    return () => observer.disconnect()
+  }, [years])
+
+  const chartData = contributions.filter(c => years.includes(c.year))
+
   return (
-    <div className="snap-y snap-mandatory">
-      {years.map(year => (
-        <section key={year} className="snap-start min-h-screen flex flex-col items-center justify-center px-4 py-20">
-          <h2 className="heading-2 mb-12">{year}</h2>
-          <div className="space-y-12 max-w-xl w-full">
-            {groups[year].map((entry, idx) => (
-              <TimelineEntry key={idx} entry={entry} />
-            ))}
-          </div>
-        </section>
-      ))}
+    <div>
+      <CommitActivityChart data={chartData} activeYear={activeYear} />
+      <div className="snap-y snap-mandatory">
+        {years.map(year => (
+          <section
+            key={year}
+            ref={el => (yearRefs.current[year] = el)}
+            data-year={year}
+            className="snap-start min-h-screen flex flex-col items-center justify-center px-4 py-20"
+          >
+            <h2 className="heading-2 mb-12">{year}</h2>
+            <div className="space-y-12 max-w-xl w-full">
+              {groups[year].map((entry, idx) => (
+                <TimelineEntry key={idx} entry={entry} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -13,6 +13,7 @@ export async function fetchRepos(username: string): Promise<Repo[]> {
     headers.Authorization = `Bearer ${process.env.GH_TOKEN}`;
   }
 
+  console.log('[github.fetchRepos] fetching repos for', username)
   const res = await fetch(`https://api.github.com/users/${username}/repos?per_page=100`, {
     headers,
     next: { revalidate: 60 * 60 },
@@ -23,7 +24,9 @@ export async function fetchRepos(username: string): Promise<Repo[]> {
   }
 
   const data = (await res.json()) as Repo[];
-  return data.filter((repo) => !repo.fork);
+  const filtered = data.filter((repo) => !repo.fork);
+  console.log('[github.fetchRepos] repos total:', data.length, 'filtered (no forks):', filtered.length)
+  return filtered;
 }
 
 export interface ContributionYear {
@@ -32,6 +35,7 @@ export interface ContributionYear {
 }
 
 export async function fetchContributions(username: string): Promise<ContributionYear[]> {
+  console.log('[github.fetchContributions] fetching contributions for', username)
   const res = await fetch(`https://github-contributions-api.jogruber.de/v4/${username}`, {
     next: { revalidate: 60 * 60 },
   });
@@ -39,5 +43,7 @@ export async function fetchContributions(username: string): Promise<Contribution
     throw new Error(`Failed to fetch contributions: ${res.status}`);
   }
   const json = (await res.json()) as { total: Record<string, number> };
-  return Object.entries(json.total).map(([year, total]) => ({ year, total }));
+  const result = Object.entries(json.total).map(([year, total]) => ({ year, total }));
+  console.log('[github.fetchContributions] years:', result.map(r => r.year), 'sum total:', result.reduce((a, c) => a + c.total, 0))
+  return result;
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -25,3 +25,19 @@ export async function fetchRepos(username: string): Promise<Repo[]> {
   const data = (await res.json()) as Repo[];
   return data.filter((repo) => !repo.fork);
 }
+
+export interface ContributionYear {
+  year: string;
+  total: number;
+}
+
+export async function fetchContributions(username: string): Promise<ContributionYear[]> {
+  const res = await fetch(`https://github-contributions-api.jogruber.de/v4/${username}`, {
+    next: { revalidate: 60 * 60 },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch contributions: ${res.status}`);
+  }
+  const json = (await res.json()) as { total: Record<string, number> };
+  return Object.entries(json.total).map(([year, total]) => ({ year, total }));
+}


### PR DESCRIPTION
## Summary
- show yearly commit activity as a sparkline on timeline
- fetch GitHub contribution totals
- highlight active year while scrolling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c28e225408328a83ed506d4c5d57c